### PR TITLE
Karran/fix/debug toolbar setup

### DIFF
--- a/src/app/settings.py
+++ b/src/app/settings.py
@@ -56,8 +56,6 @@ THIRD_PARTY_APPS = ["storages", "webpack_loader"]
 
 PROJECT_APPS = []
 
-INSTALLED_APPS = WAGTAIL_APPS + DJANGO_APPS + THIRD_PARTY_APPS + PROJECT_APPS
-
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
@@ -75,6 +73,8 @@ if ENVIRONMENT == "development":
     THIRD_PARTY_APPS += ["debug_toolbar"]
     MIDDLEWARE += ["debug_toolbar.middleware.DebugToolbarMiddleware"]
     INTERNAL_IPS = "127.0.0.1"
+
+INSTALLED_APPS = WAGTAIL_APPS + DJANGO_APPS + THIRD_PARTY_APPS + PROJECT_APPS
 
 ROOT_URLCONF = "app.urls"
 

--- a/src/app/urls.py
+++ b/src/app/urls.py
@@ -15,9 +15,11 @@ urlpatterns = [
 
 
 if settings.DEBUG:
+    import debug_toolbar
     from django.conf.urls.static import static
     from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 
     # Serve static and media files from development server
     urlpatterns += staticfiles_urlpatterns()
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+    urlpatterns += [path("__debug__/", include(debug_toolbar.urls))]

--- a/src/app/urls.py
+++ b/src/app/urls.py
@@ -4,15 +4,9 @@ from django.urls import include, path
 
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.core import urls as wagtail_urls
-from wagtail.documents import urls as wagtaildocs_urls
 
 
-urlpatterns = [
-    path('admin/', admin.site.urls),
-    path('cms/', include(wagtailadmin_urls)),
-    path('', include(wagtail_urls)),
-]
-
+urlpatterns = [path("admin/", admin.site.urls), path("cms/", include(wagtailadmin_urls))]
 
 if settings.DEBUG:
     import debug_toolbar
@@ -23,3 +17,5 @@ if settings.DEBUG:
     urlpatterns += staticfiles_urlpatterns()
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
     urlpatterns += [path("__debug__/", include(debug_toolbar.urls))]
+
+urlpatterns += [path("", include(wagtail_urls))]


### PR DESCRIPTION
1. Debug toolbar was being added to `THIRD_PARTY_APPS` after `THIRD_PARTY_APPS` assign to `INSTALLED_APPS`
2. Debug toolbar URLs were being added to `urlpatterns`
3. `wagtail_urls` has to be the last URL pattern added.